### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,9 @@ PubSubClientTools	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-publish KEYWORD2
-subscribe KEYWORD2
-resubscribe KEYWORD2
+publish	KEYWORD2
+subscribe	KEYWORD2
+resubscribe	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords